### PR TITLE
Add Updatable interface + Integrate in game loop

### DIFF
--- a/leistungstraeger-app/src/main/java/backend/abstract_object/Combatable.java
+++ b/leistungstraeger-app/src/main/java/backend/abstract_object/Combatable.java
@@ -1,6 +1,7 @@
 package backend.abstract_object;
 
 import backend.abstract_object.interaction.Interactable;
+import backend.abstract_object.interaction.Updatable;
 import backend.item.ItemStash;
 import backend.item.modifier.ActiveEffectList;
 import backend.item.modifier.TimedModifier;
@@ -12,10 +13,11 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.util.UUID;
+
 /*
 @author: Carl, Eric, Jacob, Jasper, Leon, Sven
  */
-public abstract class Combatable extends MovingAbstractObject implements Interactable {
+public abstract class Combatable extends MovingAbstractObject implements Interactable, Updatable {
 
     @Getter
     @Setter
@@ -29,7 +31,7 @@ public abstract class Combatable extends MovingAbstractObject implements Interac
 
     private final ItemStash inventory = new ItemStash();
 
-    private final ActiveEffectList activeModifiers = new ActiveEffectList();
+    protected final ActiveEffectList activeModifiers = new ActiveEffectList();
 
     public Combatable(final String name,
                       final String spriteName,
@@ -63,5 +65,10 @@ public abstract class Combatable extends MovingAbstractObject implements Interac
 
     public void applyEffect(TimedModifier effect) {
         activeModifiers.add(effect);
+    }
+
+    @Override
+    public void updateInventory() {
+        activeModifiers.update();
     }
 }

--- a/leistungstraeger-app/src/main/java/backend/abstract_object/interaction/Updatable.java
+++ b/leistungstraeger-app/src/main/java/backend/abstract_object/interaction/Updatable.java
@@ -1,0 +1,11 @@
+package backend.abstract_object.interaction;
+
+/**
+ * For all POJOs with ActiveEffectList -> GameLoop in {@class Game#update()} can access the updateMethod of
+ * every ActiveEffectList currently in game.
+ */
+public interface Updatable {
+
+    void updateInventory();
+
+}

--- a/leistungstraeger-app/src/main/java/backend/character/GameCharacter.java
+++ b/leistungstraeger-app/src/main/java/backend/character/GameCharacter.java
@@ -68,7 +68,9 @@ public class GameCharacter extends Combatable {
      */
     @Override
     public void defend(final double damage) {
-        double hpWithDefence = hitpoints + item.getModifierByIdentifier(ModifierIdentifier.DEFENCE);
+        double hpWithDefence = hitpoints
+                + item.getModifierByIdentifier(ModifierIdentifier.DEFENCE)
+                + activeModifiers.getValueForModifier(ModifierIdentifier.DEFENCE);
         hitpoints = Math.max(0, hpWithDefence - damage);
     }
 

--- a/leistungstraeger-app/src/main/java/backend/game/Game.java
+++ b/leistungstraeger-app/src/main/java/backend/game/Game.java
@@ -1,6 +1,7 @@
 package backend.game;
 
 import backend.abstract_object.AbstractObject;
+import backend.abstract_object.Combatable;
 import backend.character.GameCharacter;
 import backend.game_map.GameMap;
 import backend.network.client.Client;
@@ -18,6 +19,8 @@ import helpers.view.ViewTransformation;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
+import java.time.Instant;
+
 /*
 @author: Carl, Eric, Jacob, Jasper, Leon, Sven
  */
@@ -57,6 +60,14 @@ public class Game {
     public void newTurn() {
         characters.next();
         turnSocket.setValue(new Turn(characters.getElement()));
+        updateOnTurn();
+    }
+
+    // For updates which happen once per turn
+    private void updateOnTurn() {
+        // Update ActiveEffectLists
+        characters.toList().forEach(Combatable::updateInventory);
+        System.out.println("update".concat(Instant.now().toString()));
     }
 
     public void start() {

--- a/leistungstraeger-app/src/main/java/helpers/charactergenerator/CharacterGenerator.java
+++ b/leistungstraeger-app/src/main/java/helpers/charactergenerator/CharacterGenerator.java
@@ -4,6 +4,7 @@ import backend.character.classes.Mage;
 import backend.character.classes.Warrior;
 import backend.character.races.Dwarf;
 import backend.character.races.Hobbit;
+import backend.item.modifier.TimedModifier;
 import backend.network.client.Client;
 import backend.item.implementations.Sword;
 import backend.item.modifier.Modifier;
@@ -31,7 +32,7 @@ public class CharacterGenerator {
                 2,
                 1);
         GameCharacter character2 = new GameCharacter(
-                new Client(2),
+                client,
                 "David",
                 new Mage(),
                 new Hobbit(),
@@ -40,10 +41,19 @@ public class CharacterGenerator {
                 2,
                 1);
         character1.setItem(sword);
+        addEffect(character2);
         list.add(character1);
         list.add(character2);
         return list;
     }
+
+    private void addEffect(GameCharacter character) {
+        character.applyEffect(new TimedModifier(
+                new Modifier(ModifierIdentifier.DEFENCE, 200),
+                2));
+
+    }
+
     private int[] generateAttributes() {
         Random random = new Random();
         int[] attributes = new int[5];


### PR DESCRIPTION
Interface für ActiveEffectList-Verwender

In der GameLoop neue Methode, welche für 1x-pro-Runde updates verwendet werden kann

Der 2. Typ im Game hat einen Effect, der eine Runde lang die Wirkung des Schädelbrechers™ von Character1 annulliert. Danach kann man zuschlagen, als Test.